### PR TITLE
Add button tag helper

### DIFF
--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Sample/Views/Home/Index.cshtml
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Sample/Views/Home/Index.cshtml
@@ -275,7 +275,7 @@
         </tr>
         </tbody>
     </table>
-
+    <bs-button type="Submit" value="Click Here To Test Validation"></bs-button>
     <input type="submit" value="Click Here To Test Validation"/>
 </form>
 

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/AbstractTagHelperTest.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/AbstractTagHelperTest.cs
@@ -35,4 +35,5 @@ public abstract class AbstractTagHelperTest
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
     }
+
 }

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/ButtonTagHelperTests.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/ButtonTagHelperTests.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Html;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests;
+
+public class ButtonTagHelperTests : AbstractTagHelperTest
+{
+    private readonly ITestOutputHelper _output;
+
+    public ButtonTagHelperTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task Should_Not_Render_If_HideDisplay_Is_True()
+    {
+        var output = await (new ButtonTagHelper() { HideDisplay = true }).Render();
+        _output.WriteLine($"Output: {output.Render()}");
+        Assert.True(output.Content.IsEmptyOrWhiteSpace);
+    }
+
+    [Fact]
+    public async Task Should_Emit_Button_By_Default()
+    {
+        var output = await (new ButtonTagHelper()).Render();
+        _output.WriteLine($"Output: {output.Render()}");
+        Assert.Equal("button", output.TagName);
+        output.AssertContainsClass("btn");
+    }
+
+    [Theory]
+    [InlineData(ButtonType.Button, "button")]
+    [InlineData(ButtonType.Submit, "submit")]
+    [InlineData(ButtonType.Reset, "reset")]
+    public async Task Properly_Sets_Button_Type(ButtonType buttonType, string expectedValue)
+    {
+        var output = await (new ButtonTagHelper() { Type = buttonType }).Render();
+        _output.WriteLine($"Output: {output.Render()}");
+
+        Assert.Equal("button", output.TagName);
+        Assert.Equal(expectedValue, output.Attributes["type"].Value.ToString());
+    }
+
+    [Theory]
+    [InlineData(BootstrapColor.Info, "btn-info")]
+    [InlineData(BootstrapColor.Success, "btn-success")]
+    [InlineData(BootstrapColor.Danger, "btn-danger")]
+    [InlineData(BootstrapColor.Warning, "btn-warning")]
+    public async Task Properly_Sets_Btn_Class(BootstrapColor color, string expected)
+    {
+        var output = await (new ButtonTagHelper() { Color = color }).Render();
+        _output.WriteLine($"Output: {output.Render()}");
+        output.AssertContainsClass(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Value_Is_Not_Emitted_If_Value_Is_Null_Or_Empty(string value)
+    {
+        var output = await (new ButtonTagHelper() { Value = value }).Render();
+        _output.WriteLine($"Output: {output.Render()}");
+
+        Assert.DoesNotContain(output.Attributes, a => a.Name == "value");
+    }
+
+    [Fact]
+    public async Task Value_Attribute_Is_Set_If_Value_Has_Value()
+    {
+        var output = await (new ButtonTagHelper() { Value = "value" }).Render();
+        _output.WriteLine($"Output: {output.Render()}");
+        Assert.Equal("value", output.Attributes["value"].Value.ToString());
+    }
+
+    [Fact]
+    public async Task Emits_Disabled_Attribute_If_Disabled()
+    {
+        var output = await (new ButtonTagHelper() { Disabled = true }).Render();
+        _output.WriteLine($"Output: {output.Render()}");
+        Assert.Contains(output.Attributes, a => a.Name == "disabled");
+    }
+
+    [Theory]
+    [InlineData(ButtonSize.Small, "btn-sm")]
+    [InlineData(ButtonSize.Large, "btn-lg")]
+    public async Task Sets_Button_Size_If_Not_Normal(ButtonSize size, string expected)
+    {
+        var output = await (new ButtonTagHelper() { Size = size }).Render();
+        _output.WriteLine($"Output: {output.Render()}");
+        output.AssertContainsClass(expected);
+    }
+
+    [Fact]
+    public async Task Adds_Class_If_Block_Button()
+    {
+        var output = await (new ButtonTagHelper() { Block=true }).Render();
+        _output.WriteLine($"Output: {output.Render()}");
+        output.AssertContainsClass("btn-block");
+    }
+}
+

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/TagHelperExtensions.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/TagHelperExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Xunit;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests;
+
+public static class TagHelperExtensions
+{
+    public static async Task<TagHelperOutput> Render(this TagHelper helper)
+    {
+        var context = AbstractTagHelperTest.MakeTagHelperContext();
+        var output = AbstractTagHelperTest.MakeTagHelperOutput("");
+
+        await helper.ProcessAsync(context, output);
+        
+        return output;
+    }
+
+    public static string Render(this TagHelperOutput tagOutput)
+    {
+        var writer = new StringWriter();
+        var encoder = HtmlEncoder.Create();
+        tagOutput.WriteTo(writer, encoder);
+
+        return writer.ToString();
+    }
+
+    public static void AssertContainsClass(this TagHelperOutput output, string className)
+    {
+        var tagClasses = output.Attributes["class"].Value.ToString()?.Split(' ');
+        Assert.Contains(tagClasses, s => s == className);
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers/ButtonTagHelper.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers/ButtonTagHelper.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers;
+#nullable enable
+
+/// <summary>
+///     Types of button
+/// </summary>
+public enum ButtonType
+{
+    /// <summary>
+    ///     A regular button
+    /// </summary>
+    Button,
+    /// <summary>
+    ///     A form submit button
+    /// </summary>
+    Submit,
+    /// <summary>
+    ///     A form reset button
+    /// </summary>
+    Reset
+}
+
+/// <summary>
+///     Sizes of button
+/// </summary>
+public enum ButtonSize
+{
+    /// <summary>
+    ///     Normal size
+    /// </summary>
+    Normal,
+    /// <summary>
+    ///     A large button
+    /// </summary>
+    Large,
+    /// <summary>
+    ///     A small button
+    /// </summary>
+    Small
+}
+
+/// <summary>
+///     A tag helper for creating a Bootstrap button.
+/// </summary>
+[HtmlTargetElement("bs-button")]
+public class ButtonTagHelper : TagHelper
+{
+    /// <summary>
+    ///     What style of button to create.
+    /// </summary>
+    [HtmlAttributeName("bs-color")]
+    public BootstrapColor Color { get; set; } = BootstrapColor.Info;
+
+    /// <summary>
+    ///     The type of button this will be
+    /// </summary>
+    public ButtonType Type { get; set; } = ButtonType.Button;
+
+    /// <summary>
+    ///     If set to true the element will not be shown
+    /// </summary>
+    public bool HideDisplay { get; set; }
+
+    /// <summary>
+    ///     The value of this button
+    /// </summary>
+    public string? Value { get; set; }
+
+    /// <summary>
+    ///     Is this button disabled
+    /// </summary>
+    public bool Disabled { get; set; }
+
+    /// <summary>
+    ///     Is this a block level button
+    /// </summary>
+    public bool Block { get; set; }
+
+    /// <summary>
+    ///     The size of this button
+    /// </summary>
+    public ButtonSize Size { get; set; } = ButtonSize.Normal;
+
+    /// <inheritdoc/>
+    public override Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        if (HideDisplay)
+        {
+            output.SuppressOutput();
+            return Task.CompletedTask;
+        }
+        output.TagName = "button";
+        output.Attributes.Add("type", new HtmlString(Type.ToString().ToLowerInvariant()));
+        output.AddClass("btn", HtmlEncoder.Default);
+        output.AddClass($"btn-{Color.ToString().ToLowerInvariant()}", HtmlEncoder.Default);
+        output.Attributes.Add("role", new HtmlString("button"));
+
+        if (!string.IsNullOrEmpty(Value))
+        {
+            output.Attributes.Add("value", new HtmlString(Value));
+        }
+
+        if (Disabled)
+        {
+            output.Attributes.Add(new TagHelperAttribute("disabled"));
+        }
+
+        if (Size != ButtonSize.Normal)
+        {
+            output.AddClass(Size switch
+            {
+                ButtonSize.Large => "btn-lg",
+                ButtonSize.Small => "btn-sm",
+                ButtonSize.Normal => "",
+                _ => throw new ArgumentOutOfRangeException(nameof(Size))
+            }, HtmlEncoder.Default);
+        }
+
+        if (Block)
+        {
+            output.AddClass("btn-block", HtmlEncoder.Default);
+        }
+        return Task.CompletedTask;
+    }
+}
+


### PR DESCRIPTION
Add button tag helper, covering just about everything documented on the bootstrap button docs.

Closes #26 