### PR TITLE
Implement IHtmlGeneratorTesting and deduplicate code in form tag helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A collection of TagHelpers for ASP.NET Core that make utilizing the Bootstrap 4.
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=IowaComputerGurus_aspnetcore.utilities.bootstraptaghelpers&metric=security_rating)](https://sonarcloud.io/dashboard?id=IowaComputerGurus_aspnetcore.utilities.bootstraptaghelpers)
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=IowaComputerGurus_aspnetcore.utilities.bootstraptaghelpers&metric=sqale_index)](https://sonarcloud.io/dashboard?id=IowaComputerGurus_aspnetcore.utilities.bootstraptaghelpers)
 
-## Usage Expecations
+## Usage Expectations
 
 These tag helpers are only for markup display, your web project must properly include references to Bootstrap and must abide by all license and other requirements of Bootstrap for the functionality to be utilized here.  For more on how to include Bootstrap within your project please reference their documentation.
 
@@ -28,7 +28,7 @@ You must modify your `_viewimports.cshtml` file by adding
 
 ## Usage
 
-The goal of these tag helpers is to reduce the reduntant coding, and compliance with various features of not only the boostrap library but form patterns.  Within the "Samples" folder there are examples of all included tag helpers.  However, the below shows a quick example of the power of these helps.
+The goal of these tag helpers is to reduce the redundant coding, and compliance with various features of not only the Bootstrap library but form patterns.  Within the "Samples" folder there are examples of all included tag helpers.  However, the below shows a quick example of the power of these helps.
 
 ### Before Usage
 
@@ -64,8 +64,8 @@ At this time tag helpers have been implemented for the following elements.
 
 | Element | Description of Implementation |
 | --- | --- |
-| Alerts | Full support for implementation of alerts, including dismissable alerts |
-| Badges | Full support for implementation of badges of all Bootstrap color variariations |
+| Alerts | Full support for implementation of alerts, including dismissible alerts |
+| Badges | Full support for implementation of badges of all Bootstrap color variations |
 | Cards | Support for Card, Card Header, Card Header Actions, and Card body elements |
 | Environment Alert | An extension of the `<environment>` tag helper to render as an alert style |
 | Input | Support for Form input controls for anything tied to the `<input>` tag including ASP.NET Code Model Binding & Validation |

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,0 +1,6 @@
+# Testing
+
+## Usage of `Verify`
+
+This project uses [Verify](https://github.com/VerifyTests/Verify) and [Verify.AngleSharp](https://github.com/VerifyTests/Verify.AngleSharp) to check 
+that the structure of the tag helper output hasn't changed.

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,251 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+[**/FromFramework/*.cs]
+dotnet_analyzer_diagnostic.severity = none
+generated_code = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = 0
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = true
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = false:silent
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_prefer_extended_property_pattern = true
+csharp_style_prefer_not_pattern = true
+csharp_style_prefer_pattern_matching = true
+csharp_style_prefer_switch_expression = true
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true
+
+# Modifier preferences
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Code-block preferences
+csharp_prefer_braces = true:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_namespace_declarations = file_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:silent
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+[*.{cs,vb}]
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_readonly_field = true:suggestion

--- a/src/AspNetCore Bootstrap Tag Helpers.sln
+++ b/src/AspNetCore Bootstrap Tag Helpers.sln
@@ -7,9 +7,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore.Utilities.Bootst
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore.Utilities.BootstrapTagHelpers.Tests", "AspNetCore.Utilities.BootstrapTagHelpers.Tests\AspNetCore.Utilities.BootstrapTagHelpers.Tests.csproj", "{445250BD-291C-421F-AF03-E1EFF9A2E336}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCore.Utilities.BootstrapTagHelpers.Sample", "AspNetCore.Utilities.BootstrapTagHelpers.Sample\AspNetCore.Utilities.BootstrapTagHelpers.Sample.csproj", "{5CB5DF28-CF32-4692-829A-7E43CBB41CAA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore.Utilities.BootstrapTagHelpers.Sample", "AspNetCore.Utilities.BootstrapTagHelpers.Sample\AspNetCore.Utilities.BootstrapTagHelpers.Sample.csproj", "{5CB5DF28-CF32-4692-829A-7E43CBB41CAA}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{7C617DE3-B1FB-486F-9557-50B34C9CA395}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1B4EEF57-9889-481C-95CF-C38EBE96B3E5}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Sample/Views/Home/Index.cshtml
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Sample/Views/Home/Index.cshtml
@@ -275,7 +275,8 @@
         </tr>
         </tbody>
     </table>
-    <bs-button type="Submit" value="Click Here To Test Validation"></bs-button>
+    <bs-button type="Submit" value="Click Here To Test Validation" />
+    <bs-button type="Submit" value="Click Here To Test Validation">Click Here To Test Validation</bs-button>
     <input type="submit" value="Click Here To Test Validation"/>
 </form>
 

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/AbstractTagHelperTest.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/AbstractTagHelperTest.cs
@@ -1,18 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using AngleSharp.Dom;
+using AngleSharp.Html;
+using ICG.AspNetCore.Utilities.BootstrapTagHelpers.Form;
+using ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Text;
+using VerifyTests.AngleSharp;
+using Xunit.Abstractions;
 
 namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests;
+#nullable enable
 
 public abstract class AbstractTagHelperTest
 {
-    public static TagHelperContext MakeTagHelperContext(TagHelperAttributeList attributes = null)
+    public static TagHelperContext MakeTagHelperContext(string tagName = "div", TagHelperAttributeList? attributes = null)
     {
-        attributes = attributes ?? new TagHelperAttributeList();
+        attributes ??= new TagHelperAttributeList();
 
         return new TagHelperContext(
-            "div",
+            tagName,
             attributes,
             new Dictionary<object, object>(),
             Guid.NewGuid().ToString("N"));
@@ -20,10 +29,10 @@ public abstract class AbstractTagHelperTest
 
     public static TagHelperOutput MakeTagHelperOutput(
         string tagName,
-        TagHelperAttributeList attributes = null,
-        string childContent = null)
+        TagHelperAttributeList? attributes = null,
+        HtmlString? childContent = null)
     {
-        attributes = attributes ?? new TagHelperAttributeList();
+        attributes ??= new TagHelperAttributeList();
 
         return new TagHelperOutput(
             tagName,
@@ -31,9 +40,93 @@ public abstract class AbstractTagHelperTest
             (useCachedResult, encoder) =>
             {
                 var tagHelperContent = new DefaultTagHelperContent();
-                tagHelperContent.SetContent(childContent);
+                tagHelperContent.SetHtmlContent(childContent);
                 return Task.FromResult<TagHelperContent>(tagHelperContent);
             });
     }
 
+    public virtual SettingsTask VerifyTagHelper(TagHelperOutput output, Action<INodeList>? action) => Verify(output.Render())
+        .UseExtension("html")
+        .ScrubEmptyLines()
+        .PrettyPrintHtml(action);
+
+    public virtual SettingsTask VerifyTagHelper(TagHelperOutput output) => VerifyTagHelper(output, null);
+}
+
+public abstract class LoggingTagHelperTest : AbstractTagHelperTest
+{
+    protected ITestOutputHelper Output { get; }
+
+    protected LoggingTagHelperTest(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    public override SettingsTask VerifyTagHelper(TagHelperOutput output)
+    {
+        var hasWrittenOutput = false;
+        return base.VerifyTagHelper(output, (document) =>
+        {
+            if (hasWrittenOutput) return;
+            var builder = new StringBuilder();
+            var formatter = new PrettyMarkupFormatter
+            {
+                Indentation = "  ",
+                NewLine = "\n"
+            };
+            using var writer = new StringWriter(builder);
+            document.ToHtml(writer, formatter);
+            writer.Flush();
+
+            Output.WriteLine($"Output:{builder}");
+            hasWrittenOutput = true;
+        });
+    }
+}
+
+public abstract class ModelTagHelperTest<TTagHelper, TModel> : LoggingTagHelperTest where TModel : new()
+{
+    protected ModelTagHelperTest(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    internal abstract TTagHelper TagHelperFactory(IHtmlGenerator htmlGenerator, ModelExpression modelExpression, ViewContext viewContext);
+
+    protected TTagHelper GetTagHelper(
+        IHtmlGenerator htmlGenerator,
+        object model,
+        string propertyName,
+        IModelMetadataProvider? metadataProvider = null)
+    {
+        return GetTagHelper(
+            htmlGenerator,
+            container: new TModel(),
+            containerType: typeof(TModel),
+            model: model,
+            propertyName: propertyName,
+            expressionName: propertyName,
+            metadataProvider: metadataProvider);
+    }
+
+    protected TTagHelper GetTagHelper(
+        IHtmlGenerator htmlGenerator,
+        object container,
+        Type containerType,
+        object model,
+        string propertyName,
+        string expressionName,
+        IModelMetadataProvider? metadataProvider = null)
+    {
+        metadataProvider ??= new TestModelMetadataProvider();
+
+        var containerExplorer = metadataProvider.GetModelExplorerForType(containerType, container);
+
+        var propertyMetadata = metadataProvider.GetMetadataForProperty(containerType, propertyName);
+        var modelExplorer = containerExplorer.GetExplorerForExpression(propertyMetadata, model);
+
+        var modelExpression = new ModelExpression(expressionName, modelExplorer);
+        var viewContext = TestableHtmlGenerator.GetViewContext(container, htmlGenerator, metadataProvider);
+
+        return TagHelperFactory(htmlGenerator, modelExpression, viewContext);
+    }
 }

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/AspNetCore.Utilities.BootstrapTagHelpers.Tests.csproj
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/AspNetCore.Utilities.BootstrapTagHelpers.Tests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests</RootNamespace>
     <OutputType>Library</OutputType>
+	  <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,10 +13,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="Verify.AngleSharp" Version="3.7.0" />
+    <PackageReference Include="Verify.Xunit" Version="17.2.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Environment/EnvironmentAlertTagHelperTests.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Environment/EnvironmentAlertTagHelperTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using ICG.AspNetCore.Utilities.BootstrapTagHelpers.Environment;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Moq;
 using Xunit;
@@ -41,13 +42,13 @@ public class EnvironmentAlertTagHelperTests : AbstractTagHelperTest
         //Arrange
         var existingAttributes = new TagHelperAttributeList(new List<TagHelperAttribute>
             {new("exclude", "Development")});
-        var context = MakeTagHelperContext(existingAttributes);
-        var output = MakeTagHelperOutput("environment", childContent: "My Alert Text");
+        var context = MakeTagHelperContext(attributes: existingAttributes);
+        var output = MakeTagHelperOutput("environment", childContent: new HtmlString("My Alert Text"));
         var mockEnvironment = new Mock<IWebHostEnvironment>();
         mockEnvironment.SetupProperty(g => g.EnvironmentName, "Development");
 
         //Act
-        var helper = new EnvironmentAlertTagHelper(mockEnvironment.Object){Exclude = "Development"};
+        var helper = new EnvironmentAlertTagHelper(mockEnvironment.Object) { Exclude = "Development" };
         helper.Process(context, output);
 
         //Assert

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Form/FormInputTagHelperTests.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Form/FormInputTagHelperTests.cs
@@ -1,0 +1,31 @@
+﻿using ICG.AspNetCore.Utilities.BootstrapTagHelpers.Form;
+using ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Xunit.Abstractions;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.Form;
+
+[UsesVerify]
+public sealed class FormInputTagHelperTests : ModelTagHelperTest<FormInputTagHelper, TestModel>
+{
+    public FormInputTagHelperTests(ITestOutputHelper output) : base(output)
+    {
+
+    }
+
+    [Fact]
+    public async Task Renders()
+    {
+        var metadataProvider = new TestModelMetadataProvider();
+        var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+
+        var tagHelper = GetTagHelper(htmlGenerator, model: "Test", propertyName: nameof(TestModel.TextField));
+        var output = await tagHelper.Render();
+        await VerifyTagHelper(output);
+
+    }
+    internal override FormInputTagHelper TagHelperFactory(IHtmlGenerator htmlGenerator, ModelExpression modelExpression, ViewContext viewContext)
+        => new(htmlGenerator) { For = modelExpression, ViewContext = viewContext };
+}
+

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Form/FormSelectTagHelperTests.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Form/FormSelectTagHelperTests.cs
@@ -1,0 +1,45 @@
+﻿using ICG.AspNetCore.Utilities.BootstrapTagHelpers.Form;
+using ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Xunit.Abstractions;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.Form;
+
+[UsesVerify]
+public sealed class FormSelectTagHelperTests : ModelTagHelperTest<FormSelectTagHelper, TestModel>
+{
+    public FormSelectTagHelperTests(ITestOutputHelper output) : base(output)
+    {
+
+    }
+
+    [Fact]
+    public async Task Renders()
+    {
+        var metadataProvider = new TestModelMetadataProvider();
+        var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+
+        var tagHelper = GetTagHelper(htmlGenerator, model: "Test", propertyName: nameof(TestModel.TextField));
+        var output = await tagHelper.Render();
+
+        await VerifyTagHelper(output);
+    }
+
+    [Fact]
+    public async Task Renders_Note()
+    {
+        var metadataProvider = new TestModelMetadataProvider();
+        var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+
+        var tagHelper = GetTagHelper(htmlGenerator, model: "Test", propertyName: nameof(TestModel.TextField));
+        tagHelper.Note = "A note";
+        var output = await tagHelper.Render();
+
+        await VerifyTagHelper(output);
+    }
+
+    internal override FormSelectTagHelper TagHelperFactory(IHtmlGenerator htmlGenerator, ModelExpression modelExpression, ViewContext viewContext)
+        => new (htmlGenerator) { For = modelExpression, ViewContext = viewContext };
+}
+

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Form/FormTextAreaTagHelperTests.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Form/FormTextAreaTagHelperTests.cs
@@ -1,0 +1,44 @@
+﻿using ICG.AspNetCore.Utilities.BootstrapTagHelpers.Form;
+using ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Xunit.Abstractions;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.Form;
+
+[UsesVerify]
+public sealed class FormTextAreaTagHelperTests : ModelTagHelperTest<FormTextAreaTagHelper, TestModel>
+{
+    public FormTextAreaTagHelperTests(ITestOutputHelper output) : base(output)
+    {
+
+    }
+
+    [Fact]
+    public async Task Renders()
+    {
+        var metadataProvider = new TestModelMetadataProvider();
+        var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+
+        var tagHelper = GetTagHelper(htmlGenerator, model: "Test", propertyName: nameof(TestModel.TextField));
+        var output = await tagHelper.Render();
+        await VerifyTagHelper(output);
+    }
+
+    [Fact]
+    public async Task Renders_Child_Content()
+    {
+        var metadataProvider = new TestModelMetadataProvider();
+        var htmlGenerator = new TestableHtmlGenerator(metadataProvider);
+
+        var tagHelper = GetTagHelper(htmlGenerator, model: "Test", propertyName: nameof(TestModel.TextField));
+        var output = await tagHelper.Render(childContent: new HtmlString("Some child content"));
+
+        await VerifyTagHelper(output);
+    }
+
+    internal override FormTextAreaTagHelper TagHelperFactory(IHtmlGenerator htmlGenerator, ModelExpression modelExpression, ViewContext viewContext)
+        => new (htmlGenerator) { For = modelExpression, ViewContext = viewContext };
+}
+

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Form/TestModel.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Form/TestModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.Form;
+public class TestModel
+{
+    public string TextField { get; set; }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DataAnnotationsMetadataProvider.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DataAnnotationsMetadataProvider.cs
@@ -1,0 +1,448 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+#nullable enable
+internal sealed class DataAnnotationsMetadataProvider :
+    IBindingMetadataProvider,
+    IDisplayMetadataProvider,
+    IValidationMetadataProvider
+{
+    private readonly IStringLocalizerFactory? _stringLocalizerFactory;
+    private readonly MvcOptions _options;
+    private readonly MvcDataAnnotationsLocalizationOptions _localizationOptions;
+
+    public DataAnnotationsMetadataProvider(
+        MvcOptions options,
+        IOptions<MvcDataAnnotationsLocalizationOptions> localizationOptions,
+        IStringLocalizerFactory? stringLocalizerFactory)
+    {
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if (localizationOptions == null)
+        {
+            throw new ArgumentNullException(nameof(localizationOptions));
+        }
+
+        _options = options;
+        _localizationOptions = localizationOptions.Value;
+        _stringLocalizerFactory = stringLocalizerFactory;
+    }
+
+    /// <inheritdoc />
+    public void CreateBindingMetadata(BindingMetadataProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var editableAttribute = context.Attributes.OfType<EditableAttribute>().FirstOrDefault();
+        if (editableAttribute != null)
+        {
+            context.BindingMetadata.IsReadOnly = !editableAttribute.AllowEdit;
+        }
+    }
+
+    /// <inheritdoc />
+    public void CreateDisplayMetadata(DisplayMetadataProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var attributes = context.Attributes;
+        var dataTypeAttribute = attributes.OfType<DataTypeAttribute>().FirstOrDefault();
+        var displayAttribute = attributes.OfType<DisplayAttribute>().FirstOrDefault();
+        var displayColumnAttribute = attributes.OfType<DisplayColumnAttribute>().FirstOrDefault();
+        var displayFormatAttribute = attributes.OfType<DisplayFormatAttribute>().FirstOrDefault();
+        var displayNameAttribute = attributes.OfType<DisplayNameAttribute>().FirstOrDefault();
+        var hiddenInputAttribute = attributes.OfType<HiddenInputAttribute>().FirstOrDefault();
+        var scaffoldColumnAttribute = attributes.OfType<ScaffoldColumnAttribute>().FirstOrDefault();
+        var uiHintAttribute = attributes.OfType<UIHintAttribute>().FirstOrDefault();
+
+        // Special case the [DisplayFormat] attribute hanging off an applied [DataType] attribute. This property is
+        // non-null for DataType.Currency, DataType.Date, DataType.Time, and potentially custom [DataType]
+        // subclasses. The DataType.Currency, DataType.Date, and DataType.Time [DisplayFormat] attributes have a
+        // non-null DataFormatString and the DataType.Date and DataType.Time [DisplayFormat] attributes have
+        // ApplyFormatInEditMode==true.
+        if (displayFormatAttribute == null && dataTypeAttribute != null)
+        {
+            displayFormatAttribute = dataTypeAttribute.DisplayFormat;
+        }
+
+        var displayMetadata = context.DisplayMetadata;
+
+        // ConvertEmptyStringToNull
+        if (displayFormatAttribute != null)
+        {
+            displayMetadata.ConvertEmptyStringToNull = displayFormatAttribute.ConvertEmptyStringToNull;
+        }
+
+        // DataTypeName
+        if (dataTypeAttribute != null)
+        {
+            displayMetadata.DataTypeName = dataTypeAttribute.GetDataTypeName();
+        }
+        else if (displayFormatAttribute != null && !displayFormatAttribute.HtmlEncode)
+        {
+            displayMetadata.DataTypeName = nameof(DataType.Html);
+        }
+
+        var containerType = context.Key.ContainerType ?? context.Key.ModelType;
+        IStringLocalizer? localizer = null;
+        if (_stringLocalizerFactory != null && _localizationOptions.DataAnnotationLocalizerProvider != null)
+        {
+            localizer = _localizationOptions.DataAnnotationLocalizerProvider(containerType, _stringLocalizerFactory);
+        }
+
+        // Description
+        if (displayAttribute != null)
+        {
+            if (localizer != null &&
+                !string.IsNullOrEmpty(displayAttribute.Description) &&
+                displayAttribute.ResourceType == null)
+            {
+                displayMetadata.Description = () => localizer[displayAttribute.Description];
+            }
+            else
+            {
+                displayMetadata.Description = () => displayAttribute.GetDescription();
+            }
+        }
+
+        // DisplayFormatString
+        if (displayFormatAttribute != null)
+        {
+            displayMetadata.DisplayFormatString = displayFormatAttribute.DataFormatString;
+        }
+
+        // DisplayName
+        // DisplayAttribute has precedence over DisplayNameAttribute.
+        if (displayAttribute?.GetName() != null)
+        {
+            if (localizer != null &&
+                !string.IsNullOrEmpty(displayAttribute.Name) &&
+                displayAttribute.ResourceType == null)
+            {
+                displayMetadata.DisplayName = () => localizer[displayAttribute.Name];
+            }
+            else
+            {
+                displayMetadata.DisplayName = () => displayAttribute.GetName();
+            }
+        }
+        else if (displayNameAttribute != null)
+        {
+            if (localizer != null &&
+                !string.IsNullOrEmpty(displayNameAttribute.DisplayName))
+            {
+                displayMetadata.DisplayName = () => localizer[displayNameAttribute.DisplayName];
+            }
+            else
+            {
+                displayMetadata.DisplayName = () => displayNameAttribute.DisplayName;
+            }
+        }
+
+        // EditFormatString
+        if (displayFormatAttribute != null && displayFormatAttribute.ApplyFormatInEditMode)
+        {
+            displayMetadata.EditFormatString = displayFormatAttribute.DataFormatString;
+        }
+
+        // IsEnum et cetera
+        var underlyingType = Nullable.GetUnderlyingType(context.Key.ModelType) ?? context.Key.ModelType;
+
+        if (underlyingType.IsEnum)
+        {
+            // IsEnum
+            displayMetadata.IsEnum = true;
+
+            // IsFlagsEnum
+            displayMetadata.IsFlagsEnum = underlyingType.IsDefined(typeof(FlagsAttribute), inherit: false);
+
+            // EnumDisplayNamesAndValues and EnumNamesAndValues
+            //
+            // Order EnumDisplayNamesAndValues by DisplayAttribute.Order, then by the order of Enum.GetNames().
+            // That method orders by absolute value, then its behavior is undefined (but hopefully stable).
+            // Add to EnumNamesAndValues in same order but Dictionary does not guarantee order will be preserved.
+
+            var groupedDisplayNamesAndValues = new List<KeyValuePair<EnumGroupAndName, string>>();
+            var namesAndValues = new Dictionary<string, string>();
+
+            IStringLocalizer? enumLocalizer = null;
+            if (_stringLocalizerFactory != null && _localizationOptions.DataAnnotationLocalizerProvider != null)
+            {
+                enumLocalizer = _localizationOptions.DataAnnotationLocalizerProvider(underlyingType, _stringLocalizerFactory);
+            }
+
+            var enumFields = Enum.GetNames(underlyingType)
+                .Select(name => underlyingType.GetField(name)!)
+                .OrderBy(field => field.GetCustomAttribute<DisplayAttribute>(inherit: false)?.GetOrder() ?? 1000);
+
+            foreach (var field in enumFields)
+            {
+                var groupName = GetDisplayGroup(field);
+                var value = ((Enum)field.GetValue(obj: null)!).ToString("d");
+
+                groupedDisplayNamesAndValues.Add(new KeyValuePair<EnumGroupAndName, string>(
+                    new EnumGroupAndName(
+                        groupName,
+                        () => GetDisplayName(field, enumLocalizer)),
+                    value));
+                namesAndValues.Add(field.Name, value);
+            }
+
+            displayMetadata.EnumGroupedDisplayNamesAndValues = groupedDisplayNamesAndValues;
+            displayMetadata.EnumNamesAndValues = namesAndValues;
+        }
+
+        // HasNonDefaultEditFormat
+        if (!string.IsNullOrEmpty(displayFormatAttribute?.DataFormatString) &&
+            displayFormatAttribute?.ApplyFormatInEditMode == true)
+        {
+            // Have a non-empty EditFormatString based on [DisplayFormat] from our cache.
+            if (dataTypeAttribute == null)
+            {
+                // Attributes include no [DataType]; [DisplayFormat] was applied directly.
+                displayMetadata.HasNonDefaultEditFormat = true;
+            }
+            else if (dataTypeAttribute.DisplayFormat != displayFormatAttribute)
+            {
+                // Attributes include separate [DataType] and [DisplayFormat]; [DisplayFormat] provided override.
+                displayMetadata.HasNonDefaultEditFormat = true;
+            }
+            else if (dataTypeAttribute.GetType() != typeof(DataTypeAttribute))
+            {
+                // Attributes include [DisplayFormat] copied from [DataType] and [DataType] was of a subclass.
+                // Assume the [DataType] constructor used the protected DisplayFormat setter to override its
+                // default.  That is derived [DataType] provided override.
+                displayMetadata.HasNonDefaultEditFormat = true;
+            }
+        }
+
+        // HideSurroundingHtml
+        if (hiddenInputAttribute != null)
+        {
+            displayMetadata.HideSurroundingHtml = !hiddenInputAttribute.DisplayValue;
+        }
+
+        // HtmlEncode
+        if (displayFormatAttribute != null)
+        {
+            displayMetadata.HtmlEncode = displayFormatAttribute.HtmlEncode;
+        }
+
+        // NullDisplayText
+        if (displayFormatAttribute != null)
+        {
+            displayMetadata.NullDisplayText = displayFormatAttribute.NullDisplayText;
+        }
+
+        // Order
+        if (displayAttribute?.GetOrder() is int order)
+        {
+            displayMetadata.Order = order;
+        }
+
+        // Placeholder
+        if (displayAttribute != null)
+        {
+            if (localizer != null &&
+                !string.IsNullOrEmpty(displayAttribute.Prompt) &&
+                displayAttribute.ResourceType == null)
+            {
+                displayMetadata.Placeholder = () => localizer[displayAttribute.Prompt];
+            }
+            else
+            {
+                displayMetadata.Placeholder = () => displayAttribute.GetPrompt();
+            }
+        }
+
+        // ShowForDisplay
+        if (scaffoldColumnAttribute != null)
+        {
+            displayMetadata.ShowForDisplay = scaffoldColumnAttribute.Scaffold;
+        }
+
+        // ShowForEdit
+        if (scaffoldColumnAttribute != null)
+        {
+            displayMetadata.ShowForEdit = scaffoldColumnAttribute.Scaffold;
+        }
+
+        // SimpleDisplayProperty
+        if (displayColumnAttribute != null)
+        {
+            displayMetadata.SimpleDisplayProperty = displayColumnAttribute.DisplayColumn;
+        }
+
+        // TemplateHint
+        if (uiHintAttribute != null)
+        {
+            displayMetadata.TemplateHint = uiHintAttribute.UIHint;
+        }
+        else if (hiddenInputAttribute != null)
+        {
+            displayMetadata.TemplateHint = "HiddenInput";
+        }
+    }
+
+    /// <inheritdoc />
+    public void CreateValidationMetadata(ValidationMetadataProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        // Read interface .Count once rather than per iteration
+        var contextAttributes = context.Attributes;
+        var contextAttributesCount = contextAttributes.Count;
+        var attributes = new List<object>(contextAttributesCount);
+
+        for (var i = 0; i < contextAttributesCount; i++)
+        {
+            var attribute = contextAttributes[i];
+            if (attribute is ValidationProviderAttribute validationProviderAttribute)
+            {
+                attributes.AddRange(validationProviderAttribute.GetValidationAttributes());
+            }
+            else
+            {
+                attributes.Add(attribute);
+            }
+        }
+
+        // RequiredAttribute marks a property as required by validation - this means that it
+        // must have a non-null value on the model during validation.
+        var requiredAttribute = attributes.OfType<RequiredAttribute>().FirstOrDefault();
+
+        // For non-nullable reference types, treat them as-if they had an implicit [Required].
+        // This allows the developer to specify [Required] to customize the error message, so
+        // if they already have [Required] then there's no need for us to do this check.
+        if (!_options.SuppressImplicitRequiredAttributeForNonNullableReferenceTypes &&
+            requiredAttribute == null &&
+            !context.Key.ModelType.IsValueType &&
+            context.Key.MetadataKind != ModelMetadataKind.Type)
+        {
+            var addInferredRequiredAttribute = false;
+            if (context.Key.MetadataKind == ModelMetadataKind.Type)
+            {
+                // Do nothing.
+            }
+            else if (context.Key.MetadataKind == ModelMetadataKind.Property)
+            {
+                var property = context.Key.PropertyInfo;
+                if (property is not null)
+                {
+                    addInferredRequiredAttribute = IsRequired(context);
+                }
+            }
+            else if (context.Key.MetadataKind == ModelMetadataKind.Parameter)
+            {
+                // If the default value is assigned we don't need to check the nullabilty
+                // since the parameter will be optional.
+                if (!context.Key.ParameterInfo!.HasDefaultValue)
+                {
+                    addInferredRequiredAttribute = IsRequired(context);
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("Unsupported ModelMetadataKind: " + context.Key.MetadataKind);
+            }
+
+            if (addInferredRequiredAttribute)
+            {
+                // Since this behavior specifically relates to non-null-ness, we will use the non-default
+                // option to tolerate empty/whitespace strings. empty/whitespace INPUT will still result in
+                // a validation error by default because we convert empty/whitespace strings to null
+                // unless you say otherwise.
+                requiredAttribute = new RequiredAttribute()
+                {
+                    AllowEmptyStrings = true,
+                };
+                attributes.Add(requiredAttribute);
+            }
+        }
+
+        if (requiredAttribute != null)
+        {
+            context.ValidationMetadata.IsRequired = true;
+        }
+
+        foreach (var attribute in attributes.OfType<ValidationAttribute>())
+        {
+            // If another provider has already added this attribute, do not repeat it.
+            // This will prevent attributes like RemoteAttribute (which implement ValidationAttribute and
+            // IClientModelValidator) to be added to the ValidationMetadata twice.
+            // This is to ensure we do not end up with duplication validation rules on the client side.
+            if (!context.ValidationMetadata.ValidatorMetadata.Contains(attribute))
+            {
+                context.ValidationMetadata.ValidatorMetadata.Add(attribute);
+            }
+        }
+    }
+
+    private static string GetDisplayName(FieldInfo field, IStringLocalizer? stringLocalizer)
+    {
+        var display = field.GetCustomAttribute<DisplayAttribute>(inherit: false);
+        if (display != null)
+        {
+            // Note [Display(Name = "")] is allowed but we will not attempt to localize the empty name.
+            var name = display.GetName();
+            if (stringLocalizer != null && !string.IsNullOrEmpty(name) && display.ResourceType == null)
+            {
+                name = stringLocalizer[name];
+            }
+
+            return name ?? field.Name;
+        }
+
+        return field.Name;
+    }
+
+    // Return non-empty group specified in a [Display] attribute for a field, if any; string.Empty otherwise.
+    private static string GetDisplayGroup(FieldInfo field)
+    {
+        var display = field.GetCustomAttribute<DisplayAttribute>(inherit: false);
+        if (display != null)
+        {
+            // Note [Display(Group = "")] is allowed.
+            var group = display.GetGroupName();
+            if (group != null)
+            {
+                return group;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    internal static bool IsRequired(ValidationMetadataProviderContext context)
+    {
+        var nullabilityContext = new NullabilityInfoContext();
+        var nullability = context.Key.MetadataKind switch
+        {
+            ModelMetadataKind.Parameter => nullabilityContext.Create(context.Key.ParameterInfo!),
+            ModelMetadataKind.Property => nullabilityContext.Create(context.Key.PropertyInfo!),
+            _ => null
+        };
+        var isOptional = nullability != null && nullability.ReadState != NullabilityState.NotNull;
+        return !isOptional;
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DataAnnotationsModelValidator.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DataAnnotationsModelValidator.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.Extensions.Localization;
+using System.ComponentModel.DataAnnotations;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+#nullable enable
+
+internal sealed class DataAnnotationsModelValidator : IModelValidator
+{
+    private static readonly object _emptyValidationContextInstance = new object();
+    private readonly IStringLocalizer? _stringLocalizer;
+    private readonly IValidationAttributeAdapterProvider _validationAttributeAdapterProvider;
+
+    /// <summary>
+    ///  Create a new instance of <see cref="DataAnnotationsModelValidator"/>.
+    /// </summary>
+    /// <param name="attribute">The <see cref="ValidationAttribute"/> that defines what we're validating.</param>
+    /// <param name="stringLocalizer">The <see cref="IStringLocalizer"/> used to create messages.</param>
+    /// <param name="validationAttributeAdapterProvider">The <see cref="IValidationAttributeAdapterProvider"/>
+    /// which <see cref="ValidationAttributeAdapter{TAttribute}"/>'s will be created from.</param>
+    public DataAnnotationsModelValidator(
+        IValidationAttributeAdapterProvider validationAttributeAdapterProvider,
+        ValidationAttribute attribute,
+        IStringLocalizer? stringLocalizer)
+    {
+        if (validationAttributeAdapterProvider == null)
+        {
+            throw new ArgumentNullException(nameof(validationAttributeAdapterProvider));
+        }
+
+        if (attribute == null)
+        {
+            throw new ArgumentNullException(nameof(attribute));
+        }
+
+        _validationAttributeAdapterProvider = validationAttributeAdapterProvider;
+        Attribute = attribute;
+        _stringLocalizer = stringLocalizer;
+    }
+
+    /// <summary>
+    /// The attribute being validated against.
+    /// </summary>
+    public ValidationAttribute Attribute { get; }
+
+    /// <summary>
+    /// Validates the context against the <see cref="ValidationAttribute"/>.
+    /// </summary>
+    /// <param name="validationContext">The context being validated.</param>
+    /// <returns>An enumerable of the validation results.</returns>
+    public IEnumerable<ModelValidationResult> Validate(ModelValidationContext validationContext)
+    {
+        if (validationContext == null)
+        {
+            throw new ArgumentNullException(nameof(validationContext));
+        }
+        var metadata = validationContext.ModelMetadata;
+        var memberName = metadata.Name;
+        var container = validationContext.Container;
+
+        var context = new ValidationContext(
+            instance: container ?? validationContext.Model ?? _emptyValidationContextInstance,
+            serviceProvider: validationContext.ActionContext?.HttpContext?.RequestServices,
+            items: null)
+        {
+            DisplayName = metadata.GetDisplayName(),
+            MemberName = memberName
+        };
+
+        var result = Attribute.GetValidationResult(validationContext.Model, context);
+        if (result is not null)
+        {
+            string? errorMessage;
+            if (_stringLocalizer != null &&
+                !string.IsNullOrEmpty(Attribute.ErrorMessage) &&
+                string.IsNullOrEmpty(Attribute.ErrorMessageResourceName) &&
+                Attribute.ErrorMessageResourceType == null)
+            {
+                errorMessage = GetErrorMessage(validationContext) ?? result.ErrorMessage;
+            }
+            else
+            {
+                errorMessage = result.ErrorMessage;
+            }
+
+            var validationResults = new List<ModelValidationResult>();
+            if (result.MemberNames != null)
+            {
+                foreach (var resultMemberName in result.MemberNames)
+                {
+                    // ModelValidationResult.MemberName is used by invoking validators (such as ModelValidator) to
+                    // append construct the ModelKey for ModelStateDictionary. When validating at type level we
+                    // want the returned MemberNames if specified (e.g. "person.Address.FirstName"). For property
+                    // validation, the ModelKey can be constructed using the ModelMetadata and we should ignore
+                    // MemberName (we don't want "person.Name.Name"). However the invoking validator does not have
+                    // a way to distinguish between these two cases. Consequently we'll only set MemberName if this
+                    // validation returns a MemberName that is different from the property being validated.
+                    var newMemberName = string.Equals(resultMemberName, memberName, StringComparison.Ordinal) ?
+                        null :
+                        resultMemberName;
+                    var validationResult = new ModelValidationResult(newMemberName, errorMessage);
+
+                    validationResults.Add(validationResult);
+                }
+            }
+
+            if (validationResults.Count == 0)
+            {
+                // result.MemberNames was null or empty.
+                validationResults.Add(new ModelValidationResult(memberName: null, message: errorMessage));
+            }
+
+            return validationResults;
+        }
+
+        return Enumerable.Empty<ModelValidationResult>();
+    }
+
+    private string? GetErrorMessage(ModelValidationContextBase validationContext)
+    {
+        var adapter = _validationAttributeAdapterProvider.GetAttributeAdapter(Attribute, _stringLocalizer);
+        return adapter?.GetErrorMessage(validationContext);
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DataAnnotationsModelValidatorProvider.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DataAnnotationsModelValidatorProvider.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using System.ComponentModel.DataAnnotations;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+#nullable enable
+
+internal sealed class DataAnnotationsModelValidatorProvider : IMetadataBasedModelValidatorProvider
+{
+    private readonly IOptions<MvcDataAnnotationsLocalizationOptions> _options;
+    private readonly IStringLocalizerFactory? _stringLocalizerFactory;
+    private readonly IValidationAttributeAdapterProvider _validationAttributeAdapterProvider;
+
+    /// <summary>
+    /// Create a new instance of <see cref="DataAnnotationsModelValidatorProvider"/>.
+    /// </summary>
+    /// <param name="validationAttributeAdapterProvider">The <see cref="IValidationAttributeAdapterProvider"/>
+    /// that supplies <see cref="IAttributeAdapter"/>s.</param>
+    /// <param name="options">The <see cref="IOptions{MvcDataAnnotationsLocalizationOptions}"/>.</param>
+    /// <param name="stringLocalizerFactory">The <see cref="IStringLocalizerFactory"/>.</param>
+    /// <remarks><paramref name="options"/> and <paramref name="stringLocalizerFactory"/>
+    /// are nullable only for testing ease.</remarks>
+    public DataAnnotationsModelValidatorProvider(
+        IValidationAttributeAdapterProvider validationAttributeAdapterProvider,
+        IOptions<MvcDataAnnotationsLocalizationOptions> options,
+        IStringLocalizerFactory? stringLocalizerFactory)
+    {
+        if (validationAttributeAdapterProvider == null)
+        {
+            throw new ArgumentNullException(nameof(validationAttributeAdapterProvider));
+        }
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        _validationAttributeAdapterProvider = validationAttributeAdapterProvider;
+        _options = options;
+        _stringLocalizerFactory = stringLocalizerFactory;
+    }
+
+    public void CreateValidators(ModelValidatorProviderContext context)
+    {
+        IStringLocalizer? stringLocalizer = null;
+        if (_stringLocalizerFactory != null && _options.Value.DataAnnotationLocalizerProvider != null)
+        {
+            stringLocalizer = _options.Value.DataAnnotationLocalizerProvider(
+                context.ModelMetadata.ContainerType ?? context.ModelMetadata.ModelType,
+                _stringLocalizerFactory);
+        }
+
+        var results = context.Results;
+        // Read interface .Count once rather than per iteration
+        var resultsCount = results.Count;
+        for (var i = 0; i < resultsCount; i++)
+        {
+            var validatorItem = results[i];
+            if (validatorItem.Validator != null)
+            {
+                continue;
+            }
+
+            if (!(validatorItem.ValidatorMetadata is ValidationAttribute attribute))
+            {
+                continue;
+            }
+
+            var validator = new DataAnnotationsModelValidator(
+                _validationAttributeAdapterProvider,
+                attribute,
+                stringLocalizer);
+
+            validatorItem.Validator = validator;
+            validatorItem.IsReusable = true;
+            // Inserts validators based on whether or not they are 'required'. We want to run
+            // 'required' validators first so that we get the best possible error message.
+            if (attribute is RequiredAttribute)
+            {
+                context.Results.Remove(validatorItem);
+                context.Results.Insert(0, validatorItem);
+            }
+        }
+
+        // Produce a validator if the type supports IValidatableObject
+        if (typeof(IValidatableObject).IsAssignableFrom(context.ModelMetadata.ModelType))
+        {
+            context.Results.Add(new ValidatorItem
+            {
+                Validator = new ValidatableObjectAdapter(),
+                IsReusable = true
+            });
+        }
+    }
+
+    public bool HasValidators(Type modelType, IList<object> validatorMetadata)
+    {
+        if (typeof(IValidatableObject).IsAssignableFrom(modelType))
+        {
+            return true;
+        }
+
+        // Read interface .Count once rather than per iteration
+        var validatorMetadataCount = validatorMetadata.Count;
+        for (var i = 0; i < validatorMetadataCount; i++)
+        {
+            if (validatorMetadata[i] is ValidationAttribute)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DefaultBindingMetadataProvider.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DefaultBindingMetadataProvider.cs
@@ -1,0 +1,196 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using System.Reflection;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+
+/// A default implementation of <see cref="IBindingMetadataProvider"/>.
+/// </summary>
+internal sealed class DefaultBindingMetadataProvider : IBindingMetadataProvider
+{
+    public void CreateBindingMetadata(BindingMetadataProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        // BinderModelName
+        foreach (var binderModelNameAttribute in context.Attributes.OfType<IModelNameProvider>())
+        {
+            if (binderModelNameAttribute.Name != null)
+            {
+                context.BindingMetadata.BinderModelName = binderModelNameAttribute.Name;
+                break;
+            }
+        }
+
+        // BinderType
+        foreach (var binderTypeAttribute in context.Attributes.OfType<IBinderTypeProviderMetadata>())
+        {
+            if (binderTypeAttribute.BinderType != null)
+            {
+                context.BindingMetadata.BinderType = binderTypeAttribute.BinderType;
+                break;
+            }
+        }
+
+        // BindingSource
+        foreach (var bindingSourceAttribute in context.Attributes.OfType<IBindingSourceMetadata>())
+        {
+            if (bindingSourceAttribute.BindingSource != null)
+            {
+                context.BindingMetadata.BindingSource = bindingSourceAttribute.BindingSource;
+                break;
+            }
+        }
+
+        // PropertyFilterProvider
+        var propertyFilterProviders = context.Attributes.OfType<IPropertyFilterProvider>().ToArray();
+        if (propertyFilterProviders.Length == 0)
+        {
+            context.BindingMetadata.PropertyFilterProvider = null;
+        }
+        else if (propertyFilterProviders.Length == 1)
+        {
+            context.BindingMetadata.PropertyFilterProvider = propertyFilterProviders[0];
+        }
+        else
+        {
+            var composite = new CompositePropertyFilterProvider(propertyFilterProviders);
+            context.BindingMetadata.PropertyFilterProvider = composite;
+        }
+
+        var bindingBehavior = FindBindingBehavior(context);
+        if (bindingBehavior != null)
+        {
+            context.BindingMetadata.IsBindingAllowed = bindingBehavior.Behavior != BindingBehavior.Never;
+            context.BindingMetadata.IsBindingRequired = bindingBehavior.Behavior == BindingBehavior.Required;
+        }
+
+        //if (GetBoundConstructor(context.Key.ModelType) is ConstructorInfo constructorInfo)
+        //{
+        //    context.BindingMetadata.BoundConstructor = constructorInfo;
+        //}
+    }
+
+    //internal static ConstructorInfo GetBoundConstructor(Type type)
+    //{
+    //    if (type.IsAbstract || type.IsValueType || type.IsInterface)
+    //    {
+    //        return null;
+    //    }
+
+    //    var constructors = type.GetConstructors();
+    //    if (constructors.Length == 0)
+    //    {
+    //        return null;
+    //    }
+
+    //    return GetRecordTypeConstructor(type, constructors);
+    //}
+
+    //private static ConstructorInfo GetRecordTypeConstructor(Type type, ConstructorInfo[] constructors)
+    //{
+    //    if (!IsRecordType(type))
+    //    {
+    //        return null;
+    //    }
+
+    //    // For record types, we will support binding and validating the primary constructor.
+    //    // There isn't metadata to identify a primary constructor. Our heuristic is:
+    //    // We require exactly one constructor to be defined on the type, and that every parameter on
+    //    // that constructor is mapped to a property with the same name and type.
+
+    //    if (constructors.Length > 1)
+    //    {
+    //        return null;
+    //    }
+
+    //    var constructor = constructors[0];
+
+    //    var parameters = constructor.GetParameters();
+    //    if (parameters.Length == 0)
+    //    {
+    //        // We do not need to do special handling for parameterless constructors.
+    //        return null;
+    //    }
+
+    //    var properties = PropertyHelper.GetVisibleProperties(type);
+
+    //    for (var i = 0; i < parameters.Length; i++)
+    //    {
+    //        var parameter = parameters[i];
+    //        var mappedProperty = properties.FirstOrDefault(property =>
+    //            string.Equals(property.Name, parameter.Name, StringComparison.Ordinal) &&
+    //            property.Property.PropertyType == parameter.ParameterType);
+
+    //        if (mappedProperty is null)
+    //        {
+    //            // No property found, this is not a primary constructor.
+    //            return null;
+    //        }
+    //    }
+
+    //    return constructor;
+
+    //    static bool IsRecordType(Type type)
+    //    {
+    //        // Based on the state of the art as described in https://github.com/dotnet/roslyn/issues/45777
+    //        var cloneMethod = type.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance);
+    //        return cloneMethod != null && (cloneMethod.ReturnType == type || cloneMethod.ReturnType == type.BaseType);
+    //    }
+    //}
+
+    private static BindingBehaviorAttribute FindBindingBehavior(BindingMetadataProviderContext context)
+    {
+        switch (context.Key.MetadataKind)
+        {
+            case ModelMetadataKind.Property:
+                // BindingBehavior can fall back to attributes on the Container Type, but we should ignore
+                // attributes on the Property Type.
+                var matchingAttributes = context.PropertyAttributes!.OfType<BindingBehaviorAttribute>();
+                return matchingAttributes.FirstOrDefault()
+                       ?? context.Key.ContainerType!
+                           .GetCustomAttributes(typeof(BindingBehaviorAttribute), inherit: true)
+                           .OfType<BindingBehaviorAttribute>()
+                           .FirstOrDefault();
+            case ModelMetadataKind.Parameter:
+                return context.ParameterAttributes!.OfType<BindingBehaviorAttribute>().FirstOrDefault();
+            default:
+                return null;
+        }
+    }
+
+    private sealed class CompositePropertyFilterProvider : IPropertyFilterProvider
+    {
+        private readonly IEnumerable<IPropertyFilterProvider> _providers;
+
+        public CompositePropertyFilterProvider(IEnumerable<IPropertyFilterProvider> providers)
+        {
+            _providers = providers;
+        }
+
+        public Func<ModelMetadata, bool> PropertyFilter => CreatePropertyFilter();
+
+        private Func<ModelMetadata, bool> CreatePropertyFilter()
+        {
+            var propertyFilters = _providers
+                .Select(p => p.PropertyFilter)
+                .Where(p => p != null);
+
+            return (m) =>
+            {
+                foreach (var propertyFilter in propertyFilters)
+                {
+                    if (!propertyFilter(m))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            };
+        }
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DefaultCompositeMetadataDetailsProvider.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DefaultCompositeMetadataDetailsProvider.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+
+/// <summary>
+/// A default implementation of <see cref="ICompositeMetadataDetailsProvider"/>.
+/// </summary>
+#pragma warning disable CA1852 // Seal internal types
+internal class DefaultCompositeMetadataDetailsProvider : ICompositeMetadataDetailsProvider
+#pragma warning restore CA1852 // Seal internal types
+{
+    private readonly IEnumerable<IMetadataDetailsProvider> _providers;
+
+    /// <summary>
+    /// Creates a new <see cref="DefaultCompositeMetadataDetailsProvider"/>.
+    /// </summary>
+    /// <param name="providers">The set of <see cref="IMetadataDetailsProvider"/> instances.</param>
+    public DefaultCompositeMetadataDetailsProvider(IEnumerable<IMetadataDetailsProvider> providers)
+    {
+        _providers = providers;
+    }
+
+    /// <inheritdoc />
+    public void CreateBindingMetadata(BindingMetadataProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        foreach (var provider in _providers.OfType<IBindingMetadataProvider>())
+        {
+            provider.CreateBindingMetadata(context);
+        }
+    }
+
+    /// <inheritdoc />
+    public void CreateDisplayMetadata(DisplayMetadataProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        foreach (var provider in _providers.OfType<IDisplayMetadataProvider>())
+        {
+            provider.CreateDisplayMetadata(context);
+        }
+    }
+
+    /// <inheritdoc />
+    public void CreateValidationMetadata(ValidationMetadataProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        foreach (var provider in _providers.OfType<IValidationMetadataProvider>())
+        {
+            provider.CreateValidationMetadata(context);
+        }
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DefaultModelValidatorProvider.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DefaultModelValidatorProvider.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+
+internal sealed class DefaultModelValidatorProvider : IMetadataBasedModelValidatorProvider
+{
+    /// <inheritdoc />
+    public void CreateValidators(ModelValidatorProviderContext context)
+    {
+        //Perf: Avoid allocations here
+        for (var i = 0; i < context.Results.Count; i++)
+        {
+            var validatorItem = context.Results[i];
+
+            // Don't overwrite anything that was done by a previous provider.
+            if (validatorItem.Validator != null)
+            {
+                continue;
+            }
+
+            if (validatorItem.ValidatorMetadata is IModelValidator validator)
+            {
+                validatorItem.Validator = validator;
+                validatorItem.IsReusable = true;
+            }
+        }
+    }
+
+    public bool HasValidators(Type modelType, IList<object> validatorMetadata)
+    {
+        for (var i = 0; i < validatorMetadata.Count; i++)
+        {
+            if (validatorMetadata[i] is IModelValidator)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DefaultValidationMetadataProvider.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/DefaultValidationMetadataProvider.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+
+internal sealed class DefaultValidationMetadataProvider : IValidationMetadataProvider
+{
+    /// <inheritdoc />
+    public void CreateValidationMetadata(ValidationMetadataProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        foreach (var attribute in context.Attributes)
+        {
+            if (attribute is IModelValidator || attribute is IClientModelValidator)
+            {
+                // If another provider has already added this attribute, do not repeat it.
+                // This will prevent attributes like RemoteAttribute (which implement ValidationAttribute and
+                // IClientModelValidator) to be added to the ValidationMetadata twice.
+                // This is to ensure we do not end up with duplication validation rules on the client side.
+                if (!context.ValidationMetadata.ValidatorMetadata.Contains(attribute))
+                {
+                    context.ValidationMetadata.ValidatorMetadata.Add(attribute);
+                }
+            }
+        }
+
+        // IPropertyValidationFilter attributes on a type affect properties in that type, not properties that have
+        // that type. Thus, we ignore context.TypeAttributes for properties and not check at all for types.
+        if (context.Key.MetadataKind == ModelMetadataKind.Property)
+        {
+            var validationFilter = context.PropertyAttributes!.OfType<IPropertyValidationFilter>().FirstOrDefault();
+            if (validationFilter == null)
+            {
+                // No IPropertyValidationFilter attributes on the property.
+                // Check if container has such an attribute.
+                validationFilter = context.Key.ContainerType!
+                    .GetCustomAttributes(inherit: true)
+                    .OfType<IPropertyValidationFilter>()
+                    .FirstOrDefault();
+            }
+
+            context.ValidationMetadata.PropertyValidationFilter = validationFilter;
+        }
+        else if (context.Key.MetadataKind == ModelMetadataKind.Parameter)
+        {
+            var validationFilter = context.ParameterAttributes!.OfType<IPropertyValidationFilter>().FirstOrDefault();
+            context.ValidationMetadata.PropertyValidationFilter = validationFilter;
+        }
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/IMetadataBuilder.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/IMetadataBuilder.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+
+public interface IMetadataBuilder
+{
+    IMetadataBuilder BindingDetails(Action<BindingMetadata> action);
+
+    IMetadataBuilder DisplayDetails(Action<DisplayMetadata> action);
+
+    IMetadataBuilder ValidationDetails(Action<ValidationMetadata> action);
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/MetadataBuilder.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/MetadataBuilder.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+
+class MetadataBuilder : IMetadataBuilder
+{
+    readonly List<Action<BindingMetadata>> _bindingActions = new List<Action<BindingMetadata>>();
+    readonly List<Action<DisplayMetadata>> _displayActions = new List<Action<DisplayMetadata>>();
+
+    readonly ModelMetadataIdentity _key;
+    readonly List<Action<ValidationMetadata>> _valiationActions = new List<Action<ValidationMetadata>>();
+
+    public MetadataBuilder(ModelMetadataIdentity key) { _key = key; }
+
+    public IMetadataBuilder BindingDetails(Action<BindingMetadata> action)
+    {
+        _bindingActions.Add(action);
+        return this;
+    }
+
+    public IMetadataBuilder DisplayDetails(Action<DisplayMetadata> action)
+    {
+        _displayActions.Add(action);
+        return this;
+    }
+
+    public IMetadataBuilder ValidationDetails(Action<ValidationMetadata> action)
+    {
+        _valiationActions.Add(action);
+        return this;
+    }
+
+    public void Apply(BindingMetadataProviderContext context)
+    {
+        if (_key.Equals(context.Key))
+            foreach (var action in _bindingActions)
+                action(context.BindingMetadata);
+    }
+
+    public void Apply(DisplayMetadataProviderContext context)
+    {
+        if (_key.Equals(context.Key))
+            foreach (var action in _displayActions)
+                action(context.DisplayMetadata);
+    }
+
+    public void Apply(ValidationMetadataProviderContext context)
+    {
+        if (_key.Equals(context.Key))
+            foreach (var action in _valiationActions)
+                action(context.ValidationMetadata);
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/README.md
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/README.md
@@ -1,0 +1,4 @@
+# NOTICE
+
+This entire directory is lightly modified source from https://github.com/dotnet/aspnetcore so the
+tests for tag helpers can resemble the ones in the framework.

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/TestModelMetadataProvider.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/TestModelMetadataProvider.cs
@@ -1,0 +1,236 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using System.Reflection;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+#nullable enable
+
+public class TestModelMetadataProvider : DefaultModelMetadataProvider
+{
+    private static DataAnnotationsMetadataProvider CreateDefaultDataAnnotationsProvider(IStringLocalizerFactory stringLocalizerFactory)
+    {
+        var localizationOptions = Options.Create(new MvcDataAnnotationsLocalizationOptions());
+        localizationOptions.Value.DataAnnotationLocalizerProvider = (modelType, localizerFactory) => localizerFactory.Create(modelType);
+
+        return new DataAnnotationsMetadataProvider(new MvcOptions(), localizationOptions, stringLocalizerFactory);
+    }
+
+    // Creates a provider with all the defaults - includes data annotations
+    public static ModelMetadataProvider CreateDefaultProvider(IStringLocalizerFactory stringLocalizerFactory = null)
+    {
+        var detailsProviders = new List<IMetadataDetailsProvider>
+            {
+                new DefaultBindingMetadataProvider(),
+                new DefaultValidationMetadataProvider(),
+                CreateDefaultDataAnnotationsProvider(stringLocalizerFactory),
+                new DataMemberRequiredBindingMetadataProvider(),
+            };
+       
+        var compositeDetailsProvider = new DefaultCompositeMetadataDetailsProvider(detailsProviders);
+        return new DefaultModelMetadataProvider(compositeDetailsProvider, Options.Create(new MvcOptions()));
+    }
+
+    public static IModelMetadataProvider CreateDefaultProvider(IList<IMetadataDetailsProvider> providers)
+    {
+        var detailsProviders = new List<IMetadataDetailsProvider>()
+            {
+                new DefaultBindingMetadataProvider(),
+                new DefaultValidationMetadataProvider(),
+                new DataAnnotationsMetadataProvider(
+                    new MvcOptions(),
+                    Options.Create(new MvcDataAnnotationsLocalizationOptions()),
+                    stringLocalizerFactory: null),
+                new DataMemberRequiredBindingMetadataProvider(),
+            };
+
+        detailsProviders.AddRange(providers);
+        var compositeDetailsProvider = new DefaultCompositeMetadataDetailsProvider(detailsProviders);
+        return new DefaultModelMetadataProvider(compositeDetailsProvider, Options.Create(new MvcOptions()));
+    }
+
+    public static IModelMetadataProvider CreateProvider(IList<IMetadataDetailsProvider> providers)
+    {
+        var detailsProviders = new List<IMetadataDetailsProvider>();
+        if (providers != null)
+        {
+            detailsProviders.AddRange(providers);
+        }
+
+        var compositeDetailsProvider = new DefaultCompositeMetadataDetailsProvider(detailsProviders);
+        return new DefaultModelMetadataProvider(compositeDetailsProvider, Options.Create(new MvcOptions()));
+    }
+
+    private readonly TestModelMetadataDetailsProvider _detailsProvider;
+
+    public TestModelMetadataProvider()
+        : this(new TestModelMetadataDetailsProvider())
+    {
+    }
+
+    private TestModelMetadataProvider(TestModelMetadataDetailsProvider detailsProvider)
+        : base(
+              new DefaultCompositeMetadataDetailsProvider(new IMetadataDetailsProvider[]
+              {
+                      new DefaultBindingMetadataProvider(),
+                      new DefaultValidationMetadataProvider(),
+                      new DataAnnotationsMetadataProvider(
+                          new MvcOptions(),
+                          Options.Create(new MvcDataAnnotationsLocalizationOptions()),
+                          stringLocalizerFactory: null),
+                      detailsProvider
+              }),
+              Options.Create(new MvcOptions()))
+    {
+        _detailsProvider = detailsProvider;
+    }
+
+    public IMetadataBuilder ForType(Type type)
+    {
+        var key = ModelMetadataIdentity.ForType(type);
+
+        var builder = new MetadataBuilder(key);
+        _detailsProvider.Builders.Add(builder);
+        return builder;
+    }
+
+    public IMetadataBuilder ForType<TModel>()
+    {
+        return ForType(typeof(TModel));
+    }
+
+    public IMetadataBuilder ForProperty(Type containerType, string propertyName)
+    {
+        var property = containerType.GetRuntimeProperty(propertyName);
+        Assert.NotNull(property);
+
+        var key = ModelMetadataIdentity.ForProperty(property, property.PropertyType, containerType);
+
+        var builder = new MetadataBuilder(key);
+        _detailsProvider.Builders.Add(builder);
+        return builder;
+    }
+
+    public IMetadataBuilder ForParameter(ParameterInfo parameter)
+    {
+        var key = ModelMetadataIdentity.ForParameter(parameter);
+        var builder = new MetadataBuilder(key);
+        _detailsProvider.Builders.Add(builder);
+
+        return builder;
+    }
+
+    public IMetadataBuilder ForProperty<TContainer>(string propertyName)
+    {
+        return ForProperty(typeof(TContainer), propertyName);
+    }
+
+    private sealed class TestModelMetadataDetailsProvider :
+        IBindingMetadataProvider,
+        IDisplayMetadataProvider,
+        IValidationMetadataProvider
+    {
+        public List<MetadataBuilder> Builders { get; } = new List<MetadataBuilder>();
+
+        public void CreateBindingMetadata(BindingMetadataProviderContext context)
+        {
+            foreach (var builder in Builders)
+            {
+                builder.Apply(context);
+            }
+        }
+
+        public void CreateDisplayMetadata(DisplayMetadataProviderContext context)
+        {
+            foreach (var builder in Builders)
+            {
+                builder.Apply(context);
+            }
+        }
+
+        public void CreateValidationMetadata(ValidationMetadataProviderContext context)
+        {
+            foreach (var builder in Builders)
+            {
+                builder.Apply(context);
+            }
+        }
+    }
+
+    public interface IMetadataBuilder
+    {
+        IMetadataBuilder BindingDetails(Action<BindingMetadata> action);
+
+        IMetadataBuilder DisplayDetails(Action<DisplayMetadata> action);
+
+        IMetadataBuilder ValidationDetails(Action<ValidationMetadata> action);
+    }
+
+    private sealed class MetadataBuilder : IMetadataBuilder
+    {
+        private readonly List<Action<BindingMetadata>> _bindingActions = new List<Action<BindingMetadata>>();
+        private readonly List<Action<DisplayMetadata>> _displayActions = new List<Action<DisplayMetadata>>();
+        private readonly List<Action<ValidationMetadata>> _validationActions = new List<Action<ValidationMetadata>>();
+
+        private readonly ModelMetadataIdentity _key;
+
+        public MetadataBuilder(ModelMetadataIdentity key)
+        {
+            _key = key;
+        }
+
+        public void Apply(BindingMetadataProviderContext context)
+        {
+            if (_key.Equals(context.Key))
+            {
+                foreach (var action in _bindingActions)
+                {
+                    action(context.BindingMetadata);
+                }
+            }
+        }
+
+        public void Apply(DisplayMetadataProviderContext context)
+        {
+            if (_key.Equals(context.Key))
+            {
+                foreach (var action in _displayActions)
+                {
+                    action(context.DisplayMetadata);
+                }
+            }
+        }
+
+        public void Apply(ValidationMetadataProviderContext context)
+        {
+            if (_key.Equals(context.Key))
+            {
+                foreach (var action in _validationActions)
+                {
+                    action(context.ValidationMetadata);
+                }
+            }
+        }
+
+        public IMetadataBuilder BindingDetails(Action<BindingMetadata> action)
+        {
+            _bindingActions.Add(action);
+            return this;
+        }
+
+        public IMetadataBuilder DisplayDetails(Action<DisplayMetadata> action)
+        {
+            _displayActions.Add(action);
+            return this;
+        }
+
+        public IMetadataBuilder ValidationDetails(Action<ValidationMetadata> action)
+        {
+            _validationActions.Add(action);
+            return this;
+        }
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/TestModelValidatorProvider.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/TestModelValidatorProvider.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+
+public class TestModelValidatorProvider : CompositeModelValidatorProvider
+{
+    // Creates a provider with all the defaults - includes data annotations
+    public static CompositeModelValidatorProvider CreateDefaultProvider(IStringLocalizerFactory stringLocalizerFactory = null)
+    {
+        var options = Options.Create(new MvcDataAnnotationsLocalizationOptions());
+        options.Value.DataAnnotationLocalizerProvider = (modelType, localizerFactory) => localizerFactory.Create(modelType);
+
+        var providers = new IModelValidatorProvider[]
+        {
+            new DefaultModelValidatorProvider(),
+            new DataAnnotationsModelValidatorProvider(
+                new ValidationAttributeAdapterProvider(),
+                options,
+                stringLocalizerFactory)
+        };
+
+        return new TestModelValidatorProvider(providers);
+    }
+
+    public TestModelValidatorProvider(IList<IModelValidatorProvider> providers)
+        : base(providers)
+    {
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/TestOptionsManager.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/TestOptionsManager.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.Extensions.Options;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+
+public class TestOptionsManager : IOptions<AntiforgeryOptions>
+{
+    public TestOptionsManager()
+    {
+    }
+
+    public TestOptionsManager(AntiforgeryOptions options)
+    {
+        Value = options;
+    }
+
+    public AntiforgeryOptions Value { get; set; } = new AntiforgeryOptions();
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/TestableHtmlGenerator.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/TestableHtmlGenerator.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.WebEncoders.Testing;
+using Moq;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+
+public class TestableHtmlGenerator : DefaultHtmlGenerator
+{
+    private readonly IDictionary<string, object> _validationAttributes;
+
+    public TestableHtmlGenerator(IModelMetadataProvider metadataProvider)
+        : this(metadataProvider, Mock.Of<IUrlHelper>())
+    {
+    }
+
+    public TestableHtmlGenerator(IModelMetadataProvider metadataProvider, IUrlHelper urlHelper)
+        : this(
+              metadataProvider,
+              GetOptions(),
+              urlHelper,
+              validationAttributes: new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase))
+    {
+    }
+
+    public TestableHtmlGenerator(
+        IModelMetadataProvider metadataProvider,
+        IOptions<MvcViewOptions> options,
+        IUrlHelper urlHelper,
+        IDictionary<string, object> validationAttributes)
+        : base(
+              Mock.Of<IAntiforgery>(),
+              options,
+              metadataProvider,
+              CreateUrlHelperFactory(urlHelper),
+              new HtmlTestEncoder(),
+              new DefaultValidationHtmlAttributeProvider(options, metadataProvider, new ClientValidatorCache()))
+    {
+        _validationAttributes = validationAttributes;
+    }
+
+    public IDictionary<string, object> ValidationAttributes
+    {
+        get { return _validationAttributes; }
+    }
+
+    public static ViewContext GetViewContext(
+        object model,
+        IHtmlGenerator htmlGenerator,
+        IModelMetadataProvider metadataProvider)
+    {
+        return GetViewContext(model, htmlGenerator, metadataProvider, modelState: new ModelStateDictionary());
+    }
+
+    public static ViewContext GetViewContext(
+        object model,
+        IHtmlGenerator htmlGenerator,
+        IModelMetadataProvider metadataProvider,
+        ModelStateDictionary modelState)
+    {
+        var actionContext = new ActionContext(
+            new DefaultHttpContext(),
+            new RouteData(),
+            new ActionDescriptor(),
+            modelState);
+        var viewData = new ViewDataDictionary(metadataProvider, modelState)
+        {
+            Model = model,
+        };
+        var viewContext = new ViewContext(
+            actionContext,
+            Mock.Of<IView>(),
+            viewData,
+            Mock.Of<ITempDataDictionary>(),
+            TextWriter.Null,
+            new HtmlHelperOptions());
+
+        return viewContext;
+    }
+
+    public override IHtmlContent GenerateAntiforgery(ViewContext viewContext)
+    {
+        var tagBuilder = new TagBuilder("input")
+        {
+            Attributes =
+                {
+                    { "name", "__RequestVerificationToken" },
+                    { "type", "hidden" },
+                    { "value", "olJlUDjrouRNWLen4tQJhauj1Z1rrvnb3QD65cmQU1Ykqi6S4" }, // 50 chars of a token.
+                },
+        };
+
+        tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
+        return tagBuilder;
+    }
+
+    protected override void AddValidationAttributes(
+        ViewContext viewContext,
+        TagBuilder tagBuilder,
+        ModelExplorer modelExplorer,
+        string expression)
+    {
+        tagBuilder.MergeAttributes(ValidationAttributes);
+    }
+
+    private static IOptions<MvcViewOptions> GetOptions()
+    {
+        var mockOptions = new Mock<IOptions<MvcViewOptions>>();
+        mockOptions
+            .SetupGet(options => options.Value)
+            .Returns(new MvcViewOptions());
+
+        return mockOptions.Object;
+    }
+
+    private static IUrlHelperFactory CreateUrlHelperFactory(IUrlHelper urlHelper)
+    {
+        var factory = new Mock<IUrlHelperFactory>();
+        factory
+            .Setup(f => f.GetUrlHelper(It.IsAny<ActionContext>()))
+            .Returns(urlHelper);
+
+        return factory.Object;
+    }
+}
+

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/ValidatableObjectAdapter.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/FromFramework/ValidatableObjectAdapter.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using System.ComponentModel.DataAnnotations;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests.FromFramework;
+
+internal sealed class ValidatableObjectAdapter : IModelValidator
+{
+    public IEnumerable<ModelValidationResult> Validate(ModelValidationContext context)
+    {
+        var model = context.Model;
+        if (model == null)
+        {
+            return Enumerable.Empty<ModelValidationResult>();
+        }
+
+        if (!(model is IValidatableObject validatable))
+        {
+            throw new InvalidOperationException($"Incompatible type {(model.GetType())}");
+        }
+
+        // The constructed ValidationContext is intentionally slightly different from what
+        // DataAnnotationsModelValidator creates. The instance parameter would be context.Container
+        // (if non-null) in that class. But, DataAnnotationsModelValidator _also_ passes context.Model
+        // separately to any ValidationAttribute.
+        var validationContext = new ValidationContext(
+            instance: validatable,
+            serviceProvider: context.ActionContext?.HttpContext?.RequestServices,
+            items: null)
+        {
+            DisplayName = context.ModelMetadata.GetDisplayName(),
+            MemberName = context.ModelMetadata.Name,
+        };
+
+        return ConvertResults(validatable.Validate(validationContext));
+    }
+
+    private static IEnumerable<ModelValidationResult> ConvertResults(IEnumerable<ValidationResult> results)
+    {
+        foreach (var result in results)
+        {
+            if (result != ValidationResult.Success)
+            {
+                if (result.MemberNames == null || !result.MemberNames.Any())
+                {
+                    yield return new ModelValidationResult(memberName: null, message: result.ErrorMessage);
+                }
+                else
+                {
+                    foreach (var memberName in result.MemberNames)
+                    {
+                        yield return new ModelValidationResult(memberName, result.ErrorMessage);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Initializer.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/Initializer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using AngleSharp.Diffing;
+using VerifyTests;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests;
+
+public static class Initializer
+{
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        VerifyAngleSharpDiffing.Initialize();
+
+        // Shove all the verify files into a custom directory
+        VerifierSettings.DerivePathInfo((file, directory, type, method) => new(directory: Path.Combine(directory, "VerifySnapshots"), type.Name, method.Name));
+        
+        // Automatically "verify" tests on the first run
+        
+        VerifierSettings.OnFirstVerify(pair =>
+        {
+            File.Move(pair.ReceivedPath, pair.VerifiedPath);
+            return Task.CompletedTask;
+        });
+    }
+}
+

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/TagHelperExtensions.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/TagHelperExtensions.cs
@@ -1,31 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Text.Encodings.Web;
-using System.Threading.Tasks;
+﻿using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Xunit;
+using Microsoft.Extensions.WebEncoders.Testing;
 
 namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Tests;
 
 public static class TagHelperExtensions
 {
-    public static async Task<TagHelperOutput> Render(this TagHelper helper)
+    public static async Task<TagHelperOutput> Render(this TagHelper helper, string tagName = "div", HtmlString childContent = null)
     {
         var context = AbstractTagHelperTest.MakeTagHelperContext();
-        var output = AbstractTagHelperTest.MakeTagHelperOutput("");
+        var output = AbstractTagHelperTest.MakeTagHelperOutput("", childContent: childContent);
 
         await helper.ProcessAsync(context, output);
-        
+
         return output;
     }
 
     public static string Render(this TagHelperOutput tagOutput)
     {
         var writer = new StringWriter();
-        var encoder = HtmlEncoder.Create();
+        var encoder = new HtmlTestEncoder();
         tagOutput.WriteTo(writer, encoder);
 
         return writer.ToString();
@@ -33,6 +27,7 @@ public static class TagHelperExtensions
 
     public static void AssertContainsClass(this TagHelperOutput output, string className)
     {
+
         var tagClasses = output.Attributes["class"].Value.ToString()?.Split(' ');
         Assert.Contains(tagClasses, s => s == className);
     }

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Adds_Class_If_Block_Button.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Adds_Class_If_Block_Button.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info btn-block" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Emits_Disabled_Attribute_If_Disabled.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Emits_Disabled_Attribute_If_Disabled.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info" role="HtmlEncode[[button]]" disabled=""></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Omits_End_Tag_If_No_Content.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Omits_End_Tag_If_No_Content.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Btn_Class_color=Danger.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Btn_Class_color=Danger.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-danger" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Btn_Class_color=Info.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Btn_Class_color=Info.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Btn_Class_color=Success.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Btn_Class_color=Success.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-success" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Btn_Class_color=Warning.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Btn_Class_color=Warning.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-warning" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Button_Type_buttonType=Button.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Button_Type_buttonType=Button.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Button_Type_buttonType=Reset.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Button_Type_buttonType=Reset.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[reset]]" class="btn btn-info" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Button_Type_buttonType=Submit.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Properly_Sets_Button_Type_buttonType=Submit.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[submit]]" class="btn btn-info" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Renders_Child_Content.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Renders_Child_Content.verified.html
@@ -1,0 +1,3 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info" role="HtmlEncode[[button]]">
+  <i class="fas fa-trash"></i>Trash</button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Sets_Button_Size_If_Not_Normal_size=Large.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Sets_Button_Size_If_Not_Normal_size=Large.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info btn-lg" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Sets_Button_Size_If_Not_Normal_size=Small.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Sets_Button_Size_If_Not_Normal_size=Small.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info btn-sm" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Should_Emit_Button_By_Default.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Should_Emit_Button_By_Default.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Should_Not_Render_If_HideDisplay_Is_True.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Should_Not_Render_If_HideDisplay_Is_True.verified.html
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Value_Attribute_Is_Set_If_Value_Has_Value.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Value_Attribute_Is_Set_If_Value_Has_Value.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info" role="HtmlEncode[[button]]" value="HtmlEncode[[value]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Value_Is_Not_Emitted_If_Value_Is_Null_Or_Empty_value=.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Value_Is_Not_Emitted_If_Value_Is_Null_Or_Empty_value=.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Value_Is_Not_Emitted_If_Value_Is_Null_Or_Empty_value=null.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/ButtonTagHelperTests.Value_Is_Not_Emitted_If_Value_Is_Null_Or_Empty_value=null.verified.html
@@ -1,0 +1,2 @@
+﻿
+<button type="HtmlEncode[[button]]" class="btn btn-info" role="HtmlEncode[[button]]"></button>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/FormInputTagHelperTests.Renders.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/FormInputTagHelperTests.Renders.verified.html
@@ -1,0 +1,6 @@
+﻿
+<div class="form-group">
+  <label class="HtmlEncode[[control-label]]" for="HtmlEncode[[TextField]]">HtmlEncode[[TextField]]</label>
+  <input type="HtmlEncode[[text]]" id="HtmlEncode[[TextField]]" name="HtmlEncode[[TextField]]" value="HtmlEncode[[Test]]" class="HtmlEncode[[form-control]]">
+  <span class="HtmlEncode[[text-danger field-validation-valid]]" data-valmsg-for="HtmlEncode[[TextField]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+</div>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/FormSelectTagHelperTests.Renders.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/FormSelectTagHelperTests.Renders.verified.html
@@ -1,0 +1,6 @@
+﻿
+<div class="form-group">
+<label class="HtmlEncode[[control-label]]" for="HtmlEncode[[TextField]]">HtmlEncode[[TextField]]</label>
+<select id="HtmlEncode[[TextField]]" name="HtmlEncode[[TextField]]" class="HtmlEncode[[form-control]]"></select>
+  <span class="HtmlEncode[[text-danger field-validation-valid]]" data-valmsg-for="HtmlEncode[[TextField]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+</div>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/FormSelectTagHelperTests.Renders_Note.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/FormSelectTagHelperTests.Renders_Note.verified.html
@@ -1,0 +1,7 @@
+﻿
+<div class="form-group">
+  <label class="HtmlEncode[[control-label]]" for="HtmlEncode[[TextField]]">HtmlEncode[[TextField]]</label>
+  <select id="HtmlEncode[[TextField]]" name="HtmlEncode[[TextField]]" class="HtmlEncode[[form-control]]"></select>
+  <span class="HtmlEncode[[text-danger field-validation-valid]]" data-valmsg-for="HtmlEncode[[TextField]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+  <small class="form-text text-muted">A note</small>
+</div>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/FormTextAreaTagHelperTests.Renders.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/FormTextAreaTagHelperTests.Renders.verified.html
@@ -1,0 +1,6 @@
+﻿
+<div class="form-group">
+  <label class="HtmlEncode[[control-label]]" for="HtmlEncode[[TextField]]">HtmlEncode[[TextField]]</label>
+  <textarea id="HtmlEncode[[TextField]]" name="HtmlEncode[[TextField]]" class="HtmlEncode[[form-control]]">HtmlEncode[[Test]]</textarea>
+  <span class="HtmlEncode[[text-danger field-validation-valid]]" data-valmsg-for="HtmlEncode[[TextField]]" data-valmsg-replace="HtmlEncode[[true]]"></span>
+</div>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/FormTextAreaTagHelperTests.Renders_Child_Content.verified.html
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers.Tests/VerifySnapshots/FormTextAreaTagHelperTests.Renders_Child_Content.verified.html
@@ -1,0 +1,5 @@
+﻿
+<div class="form-group">
+  <label class="HtmlEncode[[control-label]]" for="HtmlEncode[[TextField]]">HtmlEncode[[TextField]]</label>
+  <textarea id="HtmlEncode[[TextField]]" name="HtmlEncode[[TextField]]" class="HtmlEncode[[form-control]]">HtmlEncode[[Test]]</textarea>
+  <span class="HtmlEncode[[text-danger field-validation-valid]]" data-valmsg-for="HtmlEncode[[TextField]]" data-valmsg-replace="HtmlEncode[[true]]"></span>Some child content</div>

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers/ButtonTagHelper.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers/ButtonTagHelper.cs
@@ -89,22 +89,22 @@ public class ButtonTagHelper : TagHelper
     public ButtonSize Size { get; set; } = ButtonSize.Normal;
 
     /// <inheritdoc/>
-    public override Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
     {
         if (HideDisplay)
         {
             output.SuppressOutput();
-            return Task.CompletedTask;
+            return;
         }
         output.TagName = "button";
-        output.Attributes.Add("type", new HtmlString(Type.ToString().ToLowerInvariant()));
+        output.Attributes.Add("type", Type.ToString().ToLowerInvariant());
         output.AddClass("btn", HtmlEncoder.Default);
         output.AddClass($"btn-{Color.ToString().ToLowerInvariant()}", HtmlEncoder.Default);
-        output.Attributes.Add("role", new HtmlString("button"));
+        output.Attributes.Add("role", "button");
 
         if (!string.IsNullOrEmpty(Value))
         {
-            output.Attributes.Add("value", new HtmlString(Value));
+            output.Attributes.Add("value",Value);
         }
 
         if (Disabled)
@@ -127,7 +127,19 @@ public class ButtonTagHelper : TagHelper
         {
             output.AddClass("btn-block", HtmlEncoder.Default);
         }
-        return Task.CompletedTask;
+
+        var content = await output.GetChildContentAsync();
+        if (content.IsEmptyOrWhiteSpace)
+        {
+            output.TagMode = TagMode.SelfClosing;
+        }
+        else
+        {
+            output.TagMode = TagMode.StartTagAndEndTag;
+            output.Content = content;
+
+        }
+        return;
     }
 }
 

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers/Form/FormElementMixin.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers/Form/FormElementMixin.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Form;
+
+internal interface IFormElementMixin
+{
+    ViewContext ViewContext { get; }
+    ModelExpression For { get; }
+
+    /// <summary>
+    /// The Html Generator used to render this tag helper
+    /// </summary>
+    IHtmlGenerator HtmlGenerator { get; }
+}
+
+internal static class FormElementMixinExtensions
+{
+    public static void StartFormGroup(this IFormElementMixin element, TagHelperOutput output)
+        => output.PreElement.AppendHtml("<div class='form-group'>");
+
+    public static void EndFormGroup(this IFormElementMixin element, TagHelperOutput output)
+        => output.PostElement.AppendHtml("</div>");
+
+    public static void AddLabel(this IFormElementMixin element, TagHelperOutput output)
+    {
+        //Generate our label
+        var label = element.HtmlGenerator.GenerateLabel(
+            element.ViewContext,
+            element.For.ModelExplorer,
+            element.For.Name, null,
+            new { @class = "control-label" });
+        output.PreElement.AppendHtml(label);
+    }
+
+    public static void AddValidationMessage(this IFormElementMixin element, TagHelperOutput output)
+    {
+        var validationMsg = element.HtmlGenerator.GenerateValidationMessage(
+            element.ViewContext,
+            element.For.ModelExplorer,
+            element.For.Name,
+            null,
+            element.ViewContext.ValidationMessageElement,
+            new { @class = "text-danger" });
+        output.PostElement.AppendHtml(validationMsg);
+    }
+}

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers/Form/FormInputTagHelper.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers/Form/FormInputTagHelper.cs
@@ -10,11 +10,11 @@ namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Form;
 ///     TagHelper for rending Bootstrap form compliant input controls with support for ASP.NET Core model Binding.  Will
 ///     include Label, Field, and validation.
 /// </summary>
-[ExcludeFromCodeCoverage] //Excluding from code coverage due to complexity 
 [RestrictChildren("form-note")]
-public class FormInputTagHelper : InputTagHelper
+public class FormInputTagHelper : InputTagHelper, IFormElementMixin
 {
-    private readonly IHtmlGenerator _generator;
+    /// <inheritdoc />
+    public IHtmlGenerator HtmlGenerator { get; }
 
     /// <summary>
     ///     Public constructor that will receive the incoming generator to leverage existing Microsoft Tag Helpers
@@ -22,7 +22,7 @@ public class FormInputTagHelper : InputTagHelper
     /// <param name="generator"></param>
     public FormInputTagHelper(IHtmlGenerator generator) : base(generator)
     {
-        _generator = generator;
+        HtmlGenerator = generator;
     }
 
     /// <summary>
@@ -42,28 +42,15 @@ public class FormInputTagHelper : InputTagHelper
         output.AddClass("form-control", HtmlEncoder.Default);
 
         //Add before div
-        output.PreElement.AppendHtml("<div class=\"form-group\">");
+        this.StartFormGroup(output);
 
         //Generate our label
-        var label = _generator.GenerateLabel(
-            ViewContext,
-            For.ModelExplorer,
-            For.Name, null,
-            new {@class = "control-label"});
-        output.PreElement.AppendHtml(label);
-
+        this.AddLabel(output);
 
         //Now, add validation message AFTER the field
-        var validationMsg = _generator.GenerateValidationMessage(
-            ViewContext,
-            For.ModelExplorer,
-            For.Name,
-            null,
-            ViewContext.ValidationMessageElement,
-            new {@class = "text-danger"});
-        output.PostElement.AppendHtml(validationMsg);
+        this.AddValidationMessage(output);
 
         //Close wrapping div
-        output.PostElement.AppendHtml("</div>");
+        this.EndFormGroup(output);
     }
 }

--- a/src/AspNetCore.Utilities.BootstrapTagHelpers/Form/FormSelectTagHelper.cs
+++ b/src/AspNetCore.Utilities.BootstrapTagHelpers/Form/FormSelectTagHelper.cs
@@ -1,76 +1,60 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Text.Encodings.Web;
+﻿using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
-namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Form
+namespace ICG.AspNetCore.Utilities.BootstrapTagHelpers.Form;
+
+/// <summary>
+/// Custom implementation of the select tag helper
+/// </summary>
+public class FormSelectTagHelper : SelectTagHelper, IFormElementMixin
 {
+    /// <inheritdoc />
+    public IHtmlGenerator HtmlGenerator { get; }
+
     /// <summary>
-    /// Custom implementation of the select tag helper
+    /// Default constructor
     /// </summary>
-    [ExcludeFromCodeCoverage]  //Excluded due to HTML Generator usage
-    public class FormSelectTagHelper : SelectTagHelper
+    /// <param name="generator">Html Generator for field generation</param>
+    public FormSelectTagHelper(IHtmlGenerator generator) : base(generator)
     {
-        private readonly IHtmlGenerator _generator;
+        HtmlGenerator = generator;
+    }
 
-        /// <summary>
-        /// Default constructor
-        /// </summary>
-        /// <param name="generator">Html Generator for field generation</param>
-        public FormSelectTagHelper(IHtmlGenerator generator) : base(generator)
-        {
-            _generator = generator;
-        }
+    /// <summary>
+    /// Allows the addition of a note to the field
+    /// </summary>
+    public string Note { get; set; }
 
-        /// <summary>
-        /// Allows the addition of a note to the field
-        /// </summary>
-        public string Note { get; set; }
+    /// <summary>
+    ///     Used to actually process the tag helper
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="output"></param>
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        //Call our base implementation
+        base.Process(context, output);
 
-        /// <summary>
-        ///     Used to actually process the tag helper
-        /// </summary>
-        /// <param name="context"></param>
-        /// <param name="output"></param>
-        public override void Process(TagHelperContext context, TagHelperOutput output)
-        {
-            //Call our base implementation
-            base.Process(context, output);
+        //Set our tag name
+        output.TagName = "select";
 
-            //Set our tag name
-            output.TagName = "select";
+        //Add the form-control class
+        output.AddClass("form-control", HtmlEncoder.Default);
+        //Add before div
 
-            //Add the form-control class
-            output.AddClass("form-control", HtmlEncoder.Default);
+        this.StartFormGroup(output);
 
-            //Add before div
-            output.PreElement.AppendHtml("<div class=\"form-group\">");
+        //Generate our label
+        this.AddLabel(output);
 
-            //Generate our label
-            var label = _generator.GenerateLabel(
-                ViewContext,
-                For.ModelExplorer,
-                For.Name, null,
-                new { @class = "control-label" });
-            output.PreElement.AppendHtml(label);
+        //Now, add validation message AFTER the field
+        this.AddValidationMessage(output);
 
+        if (!string.IsNullOrEmpty(Note))
+            output.PostElement.AppendHtml($"<small class=\"form-text text-muted\">{Note}</small>");
 
-            //Now, add validation message AFTER the field
-            var validationMsg = _generator.GenerateValidationMessage(
-                ViewContext,
-                For.ModelExplorer,
-                For.Name,
-                null,
-                ViewContext.ValidationMessageElement,
-                new { @class = "text-danger" });
-            output.PostElement.AppendHtml(validationMsg);
-
-            if (!string.IsNullOrEmpty(Note))
-                output.PostElement.AppendHtml($"<small class=\"form-text text-muted\">{Note}</small>");
-
-            //Close wrapping div
-            output.PostElement.AppendHtml("</div>");
-        }
+        this.EndFormGroup(output);
     }
 }


### PR DESCRIPTION
Resolves #20
Resolves #22 

This isn't quite as scary as the files changed makes it look.

You can basically ignore everything in the `FromFramework` directory. This is copied wholesale from aspnet, with some lines removed here and there around localization and some things I couldn't easily pull out. That combined with a few helper methods in `AbstractTagHelperTest.cs` (also pulled from aspnet) round out allowing testing of tag helpers that have a dependency on `IHtmlGenerator`.

Which that whole mess was done so I could make sure I didn't change the output of the tag helpers when removing duplicate code. To assist with that, I pulled in [Verify](https://github.com/VerifyTests/Verify) that implements snapshot testing, which is what all the random HTML files under `VerifySnapshots` are from. I'm not 100% sold on it yet, since it's a bit opinionated when it wants to suddenly open Winmerge on me.

Tests were added to the various form helpers that rely on Verify to grab a snapshot of what they looked like. I then added the `IFormElementMixin` interface that includes the `For` and `ViewContext` from the base tag helpers, and `HtmlGenerator` common to all of these specific tag helpers. Then extension methods were made for the repeated code between the helpers. I wanted to just use default interface implementation on the `IFormElementMixin` class to hold what was placed in the extension methods, hence the `Mixin`. But I discovered I couldn't actually call the default implementation from the tag helpers without a silly looking cast. So close to being an actually useful language feature...